### PR TITLE
Shouldn't use "7" for R7RS Small.

### DIFF
--- a/go.pose
+++ b/go.pose
@@ -59,7 +59,7 @@
   (intent "R6RS Rationale document - most useful version"))
 
  (entry
-  (id "7")
+  (id "7small")
   (uri "//standards.scheme.org/unofficial/errata-corrected-r7rs.pdf")
   (intent "R7RS Small Edition document - most useful version")))
 


### PR DESCRIPTION
We shouldn't use "7" for R7RS Small because R7RS Large will eventually be ready.